### PR TITLE
Dependencies update

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -69,10 +69,9 @@ slurm_args = f" --parsable --account={account} {gpu_arg} --time={time} --mem={me
 cmdline.append(slurm_args)
 
 if dependencies:
-    cmdline.append("--dependency")
     # only keep numbers in dependencies list
     dependencies = [ x for x in dependencies if x.isdigit() ]
-    cmdline.append("afterok:" + ",".join(dependencies))
+    cmdline.append("--dependency=afterok:" + ",".join(dependencies))
 
 cmdline.append(jobscript)
 


### PR DESCRIPTION
I have been recently seeing this issue while running jobs with cc-slurm:
`sbatch: error: Batch job submission failed: Job dependency problem`

I talked to @pvandyken and we figured out it might be related to the fact that the behaviour to specify dependencies might have changed from `dependency <type:job_id[:job_id][,type:job_id[:job_id]]>` to `dependency=<type:job_id[:job_id][,type:job_id[:job_id]]>` (https://hpc.nih.gov/docs/job_dependencies.html). I fixed this and I'm currently testing just in case. 