### PR TITLE
allow runtime in addition to time for resources

### DIFF
--- a/{{cookiecutter.profile_name}}/slurm-submit.py
+++ b/{{cookiecutter.profile_name}}/slurm-submit.py
@@ -30,6 +30,8 @@ else:
 #get values and set defaults
 if 'time' in job_properties["resources"].keys():
     time = min(job_properties["resources"]["time"],{{cookiecutter.max_time}})
+elif 'runtime' in job_properties["resources"].keys():
+    time = min(job_properties["resources"]["runtime"],{{cookiecutter.max_time}})
 else:  
     time = {{cookiecutter.default_time}}
 


### PR DESCRIPTION
some of our workflows using time, others (snakebatch) use runtime, this makes it compatible with both